### PR TITLE
fixes development workflow - we should not deploy on PRs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,8 +3,6 @@ name: Upload website
 on:
   push:
     branches: ["development"]
-  pull_request:
-    branches: ["development", "main"]
 
 jobs:
   build:


### PR DESCRIPTION
This will still deploy the development branch, even if we open a PR against main or development. So, it is not deploying that PR branch which is probably just confusing and also wasteful since there is no reason to trigger this action on a PR if it is not doing anything useful in that case.
The action will still be triggered on pushes to development of course.