### PR TITLE
BG Color Generalization

### DIFF
--- a/assets/static/main.css
+++ b/assets/static/main.css
@@ -308,44 +308,55 @@ a {
     padding-bottom: 1em;
 }
 
-.call-for-proposals.cta {
-    background-color: var(--green);
-    padding: 0.5em 0;
+.content-block--orange {
+    background-color: var(--orange);
 }
 
-.financial-aid {
+.content-block--yellow {
+    background-color: var(--yellow);
+}
+
+.content-block--blue {
+    background-color: var(--blue);
+}
+
+.content-block--blue-light {
     background-color: var(--blue-light);
 }
 
-.financial-aid.cta {
-    background-color: var(--blue);
-    padding: 0.5em 0;
+.content-block--blue-lighter {
+    background-color: var(--blue-lighter);
 }
 
-.updates {
-    background-color: var(--pink-light);
+.content-block--green {
+    background-color: var(--green);
 }
 
-.updates.cta {
-    background-color: var(--pink);
-    padding: 0.5em 0;
-}
-
-.sponsoring {
-    background-color: var(--red-light);
-}
-
-.sponsoring.cta {
-    background-color: var(--red);
-    padding: 0.5em 0;
-}
-
-.tickets {
+.content-block--green-light {
     background-color: var(--green-light);
 }
 
-.tickets.cta {
-    background-color: var(--green);
+.content-block--green-lighter {
+    background-color: var(--green-lighter);
+}
+
+.content-block--red {
+    background-color: var(--red);
+}
+
+.content-block--red-light {
+    background-color: var(--red-light);
+}
+
+.content-block--pink {
+    background-color: var(--pink);
+}
+
+.content-block--pink-light {
+    background-color: var(--pink-light);
+}
+
+.cta {
     padding: 0.5em 0;
 }
 
@@ -367,10 +378,6 @@ a {
     display: block;
 }
 
-.previous-editions {
-    background-color: var(--green-lighter);
-}
-
 .sponsors ul {
     list-style-type: none;
 }
@@ -379,7 +386,6 @@ a {
     display: grid;
     align-items: center;
     margin-bottom: 2em;
-
 }
 
 .sponsor.scale-90 {
@@ -459,16 +465,6 @@ a {
     color: white;
 }
 
-.subsite.call-for-proposals,
-.subsite.blog {
-    background-color: var(--green);
-}
-
-.subsite.financial-aid {
-    background-color: var(--blue);
-}
-
-
 .blog-posts {
     list-style: none;
 }
@@ -536,10 +532,6 @@ a {
 
 .subsite-title {
     padding: 4rem 0 0 0;
-}
-
-.subsite.faqs {
-    background-color: var(--blue);
 }
 
 .faqs .qa {
@@ -616,10 +608,6 @@ a {
 }
 
 /* buy ticket */
-.subsite.buy-ticket {
-    background-color: var(--green);
-}
-
 .subsite .ticket-link {
     font-size: 0.8em;
     padding-bottom: 2em;

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -60,7 +60,7 @@ We have published an initial list of accepted talks and tutorials.
 ---
 financial_aid_cta:
 
-[Check out the list of accepted talks and tutorials](/talks).
+[Check out the list of accepted talks and tutorials](/talks)
 ---
 previous_editions:
 

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<section class="subsite blog">
+<section class="subsite blog content-block--green">
     <div class="content">
       {{ this.body }}
     </div>

--- a/templates/buy-ticket.html
+++ b/templates/buy-ticket.html
@@ -16,7 +16,7 @@
   </div>
 </div>
 
-<section class="subsite buy-ticket">
+<section class="subsite content-block--green">
     <div class="content">
         {{ this.body }}
     </div>

--- a/templates/call-for-proposals.html
+++ b/templates/call-for-proposals.html
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<section class="subsite call-for-proposals">
+<section class="subsite call-for-proposals content-block--green">
   <div class="content">
     {{ this.body }}
   </div>

--- a/templates/faqs-review.html
+++ b/templates/faqs-review.html
@@ -9,7 +9,7 @@
     </div>
 </div>
 
-<section class="subsite faqs">
+<section class="subsite faqs content-block--blue">
     <div class="content">
         <ol>
             {% for section in bag('faq').sections|sort(attribute='order') %}

--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<section class="subsite faqs">
+<section class="subsite content-block--blue">
   <div class="content">
     {{ this.body }}
   </div>

--- a/templates/financial-aid.html
+++ b/templates/financial-aid.html
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-<section class="subsite financial-aid">
+<section class="subsite financial-aid content-block--blue">
   <div class="content">
     {{ this.body }}
   </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -21,49 +21,49 @@
     </div>
 </section>
 
-<section class="tickets content-block">
+<section class="content-block--green-light content-block">
   <div class="content">
     {{this.tickets }}
   </div>
 </section>
 
-<section class="tickets cta">
+<section class="content-block--green cta">
   <div class="content">
     {{this.tickets_cta}}
   </div>
 </section>
 
-<section class="financial-aid content-block">
+<section class="content-block--blue-light content-block">
   <div class="content">
     {{this.financial_aid}}
   </div>
 </section>
 
-<section class="financial-aid cta">
+<section class="content-block--blue cta">
   <div class="content">
     {{this.financial_aid_cta}}
   </div>
 </section>
 
-<section class="call-for-proposals content-block">
+<section class="content-block">
   <div class="content">
     {{this.call_for_proposals}}
   </div>
 </section>
 
-<section class="call-for-proposals cta">
+<section class="content-block--green cta">
   <div class="content">
     {{this.call_for_proposals_cta}}
   </div>
 </section>
 
-<section class="updates content-block">
+<section class="content-block--pink-light content-block">
   <div class="content">
     {{this.updates}}
   </div>
 </section>
 
-<section class="updates cta">
+<section class="content-block--pink cta">
   <div class="content">
     {{this.updates_cta}}
   </div>
@@ -92,13 +92,13 @@
     </div>
 </section>
 
-<section class="sponsoring content-block">
+<section class="content-block--red-light content-block">
   <div class="content">
     {{this.sponsoring}}
   </div>
 </section>
 
-<section class="sponsoring cta">
+<section class="content-block--red cta">
   <div class="content">
     {{this.sponsoring_cta}}
   </div>

--- a/templates/sponsoring.html
+++ b/templates/sponsoring.html
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<section class="subsite sponsoring">
+<section class="subsite content-block--red-light">
   <div class="content">
     {{ this.body }}
   </div>


### PR DESCRIPTION
The background colors are not bound to semantics anymore and can be used more flexibly.
See the PR details for the naming of the classes (they follow this naming scheme: `content-block--<color>`).

A small remark on something I stumbled upon while doing the changes: We should name the content parts on the home page properly (introducing new fields in the model etc), for example the text for the accepted talks and the link are just stored as financial aid, which makes no sense really. I assume it was to make the coloring easier, but now that the two things are not connected anymore we should use properly named fields to avoid confusion.

This closes https://github.com/PioneersHub/pyconde-website/issues/51