### PR TITLE
Revert "Bump pyyaml from 5.3.1 to 5.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==5.4 # awscli depends on pyyaml<5.5 and >=3.10 and the specified version is broken with cython 3, therefore force using this specific version
+pyyaml==5.3.1 # awscli depends on pyyaml<5.5 and >=3.10 and the specified version is broken with cython 3, therefore force using this specific version
 lektor==3.3.12
 pytanis==0.7.2
 pillow==11.1.0


### PR DESCRIPTION
This reverts commit 283a62ec23528ad1f17ecbd356c057c186e4420e.
The update break the environment. The security issues is not relevant for our setup. 
Fixes #67