### PR TITLE
fix FAQ and website inconsistencies

### DIFF
--- a/content/buy-ticket/contents.lr
+++ b/content/buy-ticket/contents.lr
@@ -12,7 +12,7 @@ Get ready to join one of the most exciting Python and AI events of the year!
 
 * Hassle-Free Planning: Tickets are fully refundable until 27 March, giving you peace of mind as you plan your
   attendance.
-* Swag Alert: All on-site tickets include a PyCon DE & PyData T-shirt! Don’t forget
+* Swag Alert: All 3-day on-site tickets include a PyCon DE & PyData T-shirt! Don’t forget
   to [select your size during checkout](/blog/t-shirt-sizes/)—shirts are pre-order only and cannot be changed after 25 March 2026.
 
 #### Team-Tickets

--- a/content/call-for-proposals/contents.lr
+++ b/content/call-for-proposals/contents.lr
@@ -116,6 +116,6 @@ We strive to maintain the Python community's reputation for being welcoming, fri
 <br>
 <br>
 
-**Submissions close on 2025-12-21 23:59 (Europe/Berlin), 1 month from now.**
+**Submissions close on 2026-01-11 23:59 (Europe/Berlin).**
 
 

--- a/content/venue/contents.lr
+++ b/content/venue/contents.lr
@@ -11,7 +11,7 @@ The Darmstadtium conference center is the host of PyCon DE & PyData 2026, schedu
 
 This architectural marvel is perfectly positioned at the heart of the city, mere steps away from the prestigious TU Darmstadt, renowned for its pioneering contributions to computer science since housing Germany's first university computer in 1957. Just as the synthetic element darmstadtium, discovered right here at the GSI Helmholtz Centre, was a groundbreaking achievement with its incredibly brief half-life of 14 seconds, the venue named in its honor is designed to foster fleeting but transformative exchanges of knowledge and collaboration.
 
-With its state-of-the-art facilities, commitment to sustainable design, and strategic location within Europe's Rhine-Main technology hub, the Darmstadtium suits perfectly for PyCon DE & PyData 2025. Get ready for an event packed with inspiration, learning, and networking at this iconic venue!
+With its state-of-the-art facilities, commitment to sustainable design, and strategic location within Europe's Rhine-Main technology hub, the Darmstadtium suits perfectly for PyCon DE & PyData 2026. Get ready for an event packed with inspiration, learning, and networking at this iconic venue!
 
 ### How to get there
 darmstadtium is located in the heart of Darmstadt.  

--- a/databags/faq.yaml
+++ b/databags/faq.yaml
@@ -16,11 +16,11 @@ sections:
     - '2025-11-19 Call for Proposals: open'
     - '2025-11-19 Financial Aid Programme: open'
     - '2025-11-19 Tickets: sale opens at 12:00 CEST'
-    - '2025-12-21 Call for Proposals: closes at 23:59 CEST'
+    - '2026-01-11 Call for Proposals: closes at 23:59 CET'
     - '2026-01-12 Community voting: open'
     - '2026-01-18 Financial Aid Programme: closes at 23:59 CEST'
     - '2026-01-19 Community voting: closes at 23:59 CEST'
-    - '2026-02-03 Call for Proposals: Acceptance notice to speakers'
+    - '2026-02-11 Call for Proposals: Acceptance notice to speakers'
     - '2026-02-11 Program: Publish list of accepted talks'
     - 2026-02-11 Switch to Late Bird pricing
     - '2026-02-14 Financial Aid Programme: notice of acceptance status'
@@ -28,7 +28,7 @@ sections:
     - '2026-03-27 Last day to return purchased tickets'
     - '2026-04-02 Last day to change ticket registration'
     - 2026-04-03 to 2026-04-06 German Easter holidays 🐤
-    - '2026-04-13 Sprints (tbc.), early badge pickup 15:00-18:00.'
+    - '2026-04-13 Sprints, early badge pickup 15:00-19:00.'
     - '2026-04-14 Conference Day 1, doors open at 8:00 CEST, start at 10:00 🚀'
     - '2026-04-15 Conference Day 2, 19:00-22:00 social event 🥳'
     - '2026-04-16 Conference Day 3, closes at ca. 16:30 CEST'
@@ -309,7 +309,7 @@ sections:
     answer: |
       You can adapt your personal information (name, contact details, etc.), but to change the T-shirt size** you need to change your order.
 
-      1. Go to your oder page, you can find the link in your oder confirmation, it looks like: https://pretix.eu/pysv/pyconde-pydata-2026/order/YOURODERID/eefnDWO7ewie/<br> 
+      1. Go to your order page, you can find the link in your order confirmation, it looks like: https://pretix.eu/pysv/pyconde-pydata-2026/order/YOURODERID/eefnDWO7ewie/<br> 
       2. Scroll to the bottom and select **"Change or cancel your order → Change order"** 
          (German: **"Bestellung stornieren oder umbuchen → Bestellung umbuchen"**)<br> 
       3. Select another T-shirt size and continue to complete the change.<br>
@@ -516,8 +516,8 @@ sections:
     section: tickets
     question: How can information on conference badges be updated?
     answer: |
-      Badge information is taken directly from the details provided through **Tito**.  
-      Any updates must be made in Tito by following the links included in the ticket confirmation emails.  
+      Badge information is taken directly from the details provided through the ticket shop.  
+      Any updates must be made in ticket shop by following the links included in the ticket confirmation emails.  
   
       The following information can be updated:
       <ol>


### PR DESCRIPTION
- Fix CfP deadline in FAQ milestones: Dec 21 → Jan 11 (after extension)
- Fix CfP page stale closing date at bottom: Dec 21 → Jan 11
- Fix speaker acceptance date in FAQ milestones: Feb 3 → Feb 11
- Fix T-shirt eligibility on ticket page: "all on-site" → "3-day on-site"
- Fix venue page year typo: 2025 → 2026
- Fix sprints milestone: remove "tbc", update badge pickup to 15:00-19:00
- Fix "oder" typo → "order" in T-shirt FAQ
- Replace Tito references with "ticket shop" in badge FAQ